### PR TITLE
fix(deps): patch vite and js-yaml Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "resolutions": {
     "postcss": "npm:postcss@8.5.12",
     "esbuild": "npm:esbuild@0.27.2",
-    "vite": "npm:vite@6.4.2",
-    "js-yaml": "npm:js-yaml@4.1.1",
+    "vite": "npm:vite@6.4.3",
+    "js-yaml": "npm:js-yaml@4.2.0",
     "base-x": "npm:base-x@5.0.1",
     "brace-expansion": "npm:brace-expansion@1.1.12"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-js-yaml@^4.1.0, "js-yaml@npm:js-yaml@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, "js-yaml@npm:js-yaml@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 
@@ -2820,10 +2820,10 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-"vite@^6.0.0 || ^7.0.0 || ^8.0.0-0", "vite@npm:vite@6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.2.tgz#a4e548ca3a90ca9f3724582cab35e1ba15efc6f2"
-  integrity sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0-0", "vite@npm:vite@6.4.3":
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.3.tgz#85a164db7ce706f2a776812efa2b340f1721858e"
+  integrity sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==
   dependencies:
     esbuild "^0.25.0"
     fdir "^6.4.4"


### PR DESCRIPTION
## Summary
- Bump `vite` resolution from 6.4.2 → 6.4.3 (Dependabot #61 high, #62 medium: Windows `server.fs.deny` bypass and UNC path hash disclosure)
- Bump `js-yaml` resolution from 4.1.1 → 4.2.0 (Dependabot #63 medium: quadratic DoS via merge key aliases)

## Test plan
- [x] `yarn install` resolves `vite@6.4.3` and `js-yaml@4.2.0`
- [x] `yarn test --run` — 82 tests passed
- [ ] Confirm Dependabot alerts #61–#63 close after merge


Made with [Cursor](https://cursor.com)