### PR TITLE
ci: bump publish workflow to Node 22

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,13 +12,13 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: yarn install
-      - run: yarn test
+      - run: yarn vitest run
       - run: yarn build
       - run: npm publish
         env:


### PR DESCRIPTION
## Summary
Publish for `@truto/replace-placeholders@1.0.9` never shipped because CI used **Node 18** while `vitest@4.1.0` requires **>=20**.

- Bump `node-version` **18 → 22** (same as `truto-ts-sdk`)
- Upgrade checkout/setup-node to v4
- Use `yarn vitest run` instead of `yarn test` (`vitest` alone stays in watch mode)

After merge, the Publish workflow should publish **1.0.9** to npm (it never reached the registry).

## Test plan
- [ ] Merge to main
- [ ] Actions → Publish succeeds
- [ ] `npm view @truto/replace-placeholders version` → **1.0.9**

Made with [Cursor](https://cursor.com)